### PR TITLE
Basic support for complex numbers

### DIFF
--- a/concept_erasure/groupby.py
+++ b/concept_erasure/groupby.py
@@ -102,6 +102,7 @@ def invert_indices(indices: Tensor) -> Tensor:
     reverse_indices = torch.empty_like(indices)
 
     # Scatter the indices to reverse the permutation
-    reverse_indices.scatter_(0, indices, torch.arange(len(indices)))
+    arange = torch.arange(len(indices), device=indices.device)
+    reverse_indices.scatter_(0, indices, arange)
 
     return reverse_indices

--- a/concept_erasure/optimal_transport.py
+++ b/concept_erasure/optimal_transport.py
@@ -14,7 +14,7 @@ def psd_sqrt(A: Tensor) -> Tensor:
     """Compute the unique p.s.d. square root of a positive semidefinite matrix."""
     L, U = torch.linalg.eigh(A)
     L = L[..., None, :].clamp_min(0.0)
-    return U * L.sqrt() @ U.mT
+    return U * L.sqrt() @ U.mH
 
 
 def psd_sqrt_rsqrt(A: Tensor) -> tuple[Tensor, Tensor]:
@@ -23,12 +23,12 @@ def psd_sqrt_rsqrt(A: Tensor) -> tuple[Tensor, Tensor]:
     L = L[..., None, :].clamp_min(0.0)
 
     # Square root is easy
-    sqrt = U * L.sqrt() @ U.mT
+    sqrt = U * L.sqrt() @ U.mH
 
     # We actually compute the pseudo-inverse here for numerical stability.
     # Use the same heuristic as `torch.linalg.pinv` to determine the tolerance.
     thresh = L[..., None, -1] * A.shape[-1] * torch.finfo(A.dtype).eps
-    rsqrt = U * torch.where(L > thresh, L.rsqrt(), 0.0) @ U.mT
+    rsqrt = U * torch.where(L > thresh, L.rsqrt(), 0.0) @ U.mH
 
     return sqrt, rsqrt
 
@@ -84,7 +84,7 @@ def ot_barycenter(
 
         # Equation 7 from Álvarez-Esteban et al. (2016)
         T = torch.sum(weights * rsqrt_mu @ inner @ rsqrt_mu, dim=0)
-        mu = T @ mu @ T.mT
+        mu = T @ mu @ T.mH
 
     return mu
 

--- a/concept_erasure/oracle.py
+++ b/concept_erasure/oracle.py
@@ -119,8 +119,8 @@ class OracleFitter:
         self.mean_z += delta_z.sum(dim=0) / self.n
         delta_z2 = z - self.mean_z
 
-        self.sigma_xz_.addmm_(delta_x.mT, delta_z2)
-        self.sigma_zz_.addmm_(delta_z.mT, delta_z2)
+        self.sigma_xz_.addmm_(delta_x.mH, delta_z2)
+        self.sigma_zz_.addmm_(delta_z.mH, delta_z2)
 
         return self
 
@@ -141,7 +141,7 @@ class OracleFitter:
         ), "Covariance statistics are not being tracked for X"
 
         # Accumulated numerical error may cause this to be slightly non-symmetric
-        S_hat = (self.sigma_zz_ + self.sigma_zz_.mT) / 2
+        S_hat = (self.sigma_zz_ + self.sigma_zz_.mH) / 2
 
         # Apply Random Matrix Theory-based shrinkage
         if self.shrinkage:

--- a/concept_erasure/oracle.py
+++ b/concept_erasure/oracle.py
@@ -93,7 +93,7 @@ class OracleFitter:
         self.mean_x = torch.zeros(x_dim, device=device, dtype=dtype)
         self.mean_z = torch.zeros(z_dim, device=device, dtype=dtype)
 
-        self.n = torch.tensor(0, device=device, dtype=dtype)
+        self.n = torch.tensor(0, device=device)
         self.sigma_xz_ = torch.zeros(x_dim, z_dim, device=device, dtype=dtype)
         self.sigma_zz_ = torch.zeros(z_dim, z_dim, device=device, dtype=dtype)
 

--- a/concept_erasure/quadratic.py
+++ b/concept_erasure/quadratic.py
@@ -115,7 +115,7 @@ class QuadraticFitter:
         self.shrinkage = shrinkage
 
         self.mean_x = torch.zeros(num_classes, x_dim, device=device, dtype=dtype)
-        self.n = torch.zeros(num_classes, device=device, dtype=torch.long)
+        self.n = torch.zeros(num_classes, device=device)
         self.sigma_xx_ = torch.zeros(
             num_classes, x_dim, x_dim, device=device, dtype=dtype
         )

--- a/concept_erasure/shrinkage.py
+++ b/concept_erasure/shrinkage.py
@@ -31,12 +31,12 @@ def optimal_linear_shrinkage(S_n: Tensor, n: int | Tensor) -> Tensor:
     trace_S = trace(S_n)
     sigma0 = eye * trace_S / p
 
-    sigma0_norm_sq = sigma0.pow(2).sum(dim=(-2, -1), keepdim=True)
-    S_norm_sq = S_n.pow(2).sum(dim=(-2, -1), keepdim=True)
+    sigma0_norm_sq = sigma0.norm(dim=(-2, -1), keepdim=True) ** 2
+    S_norm_sq = S_n.norm(dim=(-2, -1), keepdim=True) ** 2
 
     prod_trace = trace(S_n @ sigma0)
-    top = trace_S.pow(2) * sigma0_norm_sq / n
-    bottom = S_norm_sq * sigma0_norm_sq - prod_trace**2
+    top = trace_S * trace_S.conj() * sigma0_norm_sq / n
+    bottom = S_norm_sq * sigma0_norm_sq - prod_trace * prod_trace.conj()
 
     # Epsilon prevents dividing by zero for the zero matrix. In that case we end up
     # setting alpha = 0, beta = 1, but it doesn't matter since we're shrinking toward

--- a/tests/test_shrinkage.py
+++ b/tests/test_shrinkage.py
@@ -26,7 +26,7 @@ def test_olse_shrinkage(p: int, n: int):
 
     # Generate a random covariance matrix
     A = torch.randn(N, p, p)
-    S_true = A @ A.mT / p
+    S_true = A @ A.mH / p
     torch.linalg.diagonal(S_true).add_(1e-3)
 
     # Generate data with this covariance
@@ -37,7 +37,7 @@ def test_olse_shrinkage(p: int, n: int):
 
     # Compute the sample covariance matrix
     X_centered = X - X.mean(dim=0, keepdim=True)
-    S_hat = (X_centered.mT @ X_centered) / n
+    S_hat = (X_centered.mH @ X_centered) / n
 
     # Apply shrinkage
     S_olse = optimal_linear_shrinkage(S_hat, n)


### PR DESCRIPTION
`LeaceFitter`, `OracleFitter`, and `QuadraticFitter` now don't crash when you feed them `complex64` or `complex128` inputs, and pass basic tests checking that their statistics are at least computed correctly when using complex-valued vector representations.

Also, as a bonus, this PR includes the `QuadraticEditor` class for doing edits other than simple erasures using the stats from a `QuadraticFitter`.